### PR TITLE
Replacing tecommons for commonsswarm in connector 

### DIFF
--- a/API.md
+++ b/API.md
@@ -44,7 +44,7 @@ Name | Type | Description
 
 **Returns:** The Hatch instance that interacts both with the contract and the subgraph.
 
-Defined in: [Hatch.ts:20](https://github.com/TECommons/hatch-connector/blob/main/src/models/Hatch.ts#L20)
+Defined in: [Hatch.ts:20](https://github.com/CommonsSwarm/hatch-connector/blob/main/src/models/Hatch.ts#L20)
 
 ## Properties
 
@@ -52,7 +52,7 @@ Defined in: [Hatch.ts:20](https://github.com/TECommons/hatch-connector/blob/main
 
 • `Private` **#app**: App
 
-Defined in: [Hatch.ts:17](https://github.com/TECommons/hatch-connector/blob/main/src/models/Hatch.ts#L17)
+Defined in: [Hatch.ts:17](https://github.com/CommonsSwarm/hatch-connector/blob/main/src/models/Hatch.ts#L17)
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 • `Private` **#connector**: IHatchConnector
 
-Defined in: [Hatch.ts:18](https://github.com/TECommons/hatch-connector/blob/main/src/models/Hatch.ts#L18)
+Defined in: [Hatch.ts:18](https://github.com/CommonsSwarm/hatch-connector/blob/main/src/models/Hatch.ts#L18)
 
 ## Methods
 
@@ -82,7 +82,7 @@ A promise that resolves to a ForwardingPath
 object which contains all the transactions needed to be signed in order to close
 the hatch.
 
-Defined in: [Hatch.ts:199](https://github.com/TECommons/hatch-connector/blob/main/src/models/Hatch.ts#L199)
+Defined in: [Hatch.ts:199](https://github.com/CommonsSwarm/hatch-connector/blob/main/src/models/Hatch.ts#L199)
 
 ___
 
@@ -104,7 +104,7 @@ Name | Type | Description |
 A promise that resolves to a ForwardingPath object
 which contains all the transactions needed to be signed in order to contribute to the hatch.
 
-Defined in: [Hatch.ts:211](https://github.com/TECommons/hatch-connector/blob/main/src/models/Hatch.ts#L211)
+Defined in: [Hatch.ts:211](https://github.com/CommonsSwarm/hatch-connector/blob/main/src/models/Hatch.ts#L211)
 
 ___
 
@@ -129,7 +129,7 @@ Name | Type | Description
 
 A promise that resolves to an array of Contribution objects.
 
-Defined in: [Hatch.ts:135](https://github.com/TECommons/hatch-connector/blob/main/src/models/Hatch.ts#L135)
+Defined in: [Hatch.ts:135](https://github.com/CommonsSwarm/hatch-connector/blob/main/src/models/Hatch.ts#L135)
 
 ___
 
@@ -149,7 +149,7 @@ Name | Type | Default value | Description |
 
 A promise that resolves to the searched contributor.
 
-Defined in: [Hatch.ts:106](https://github.com/TECommons/hatch-connector/blob/main/src/models/Hatch.ts#L106)
+Defined in: [Hatch.ts:106](https://github.com/CommonsSwarm/hatch-connector/blob/main/src/models/Hatch.ts#L106)
 
 ___
 
@@ -173,7 +173,7 @@ Name | Type | Description
 
 A promise which resolves to an array of Contributor objects.
 
-Defined in: [Hatch.ts:64](https://github.com/TECommons/hatch-connector/blob/main/src/models/Hatch.ts#L64)
+Defined in: [Hatch.ts:64](https://github.com/CommonsSwarm/hatch-connector/blob/main/src/models/Hatch.ts#L64)
 
 ___
 
@@ -185,7 +185,7 @@ Disconnect the connector from the subgraph.
 
 **Returns:** *Promise*<void\>
 
-Defined in: [Hatch.ts:28](https://github.com/TECommons/hatch-connector/blob/main/src/models/Hatch.ts#L28)
+Defined in: [Hatch.ts:28](https://github.com/CommonsSwarm/hatch-connector/blob/main/src/models/Hatch.ts#L28)
 
 ___
 
@@ -201,7 +201,7 @@ the hatch and the hatch oracle.
 A promise that resolves to a GeneralConfig
 entity object.
 
-Defined in: [Hatch.ts:38](https://github.com/TECommons/hatch-connector/blob/main/src/models/Hatch.ts#L38)
+Defined in: [Hatch.ts:38](https://github.com/CommonsSwarm/hatch-connector/blob/main/src/models/Hatch.ts#L38)
 
 ___
 
@@ -223,7 +223,7 @@ Name | Type | Description |
 A promise that resolves to the allowed
 contribution token amount.
 
-Defined in: [Hatch.ts:273](https://github.com/TECommons/hatch-connector/blob/main/src/models/Hatch.ts#L273)
+Defined in: [Hatch.ts:273](https://github.com/CommonsSwarm/hatch-connector/blob/main/src/models/Hatch.ts#L273)
 
 ___
 
@@ -250,7 +250,7 @@ Name | Type | Description
 A function handler used to cancel the subscription
 at any time.
 
-Defined in: [Hatch.ts:160](https://github.com/TECommons/hatch-connector/blob/main/src/models/Hatch.ts#L160)
+Defined in: [Hatch.ts:160](https://github.com/CommonsSwarm/hatch-connector/blob/main/src/models/Hatch.ts#L160)
 
 ___
 
@@ -272,7 +272,7 @@ Name | Type | Default value | Description |
 A function handler used to cancel the subscription
 at any time.
 
-Defined in: [Hatch.ts:120](https://github.com/TECommons/hatch-connector/blob/main/src/models/Hatch.ts#L120)
+Defined in: [Hatch.ts:120](https://github.com/CommonsSwarm/hatch-connector/blob/main/src/models/Hatch.ts#L120)
 
 ___
 
@@ -298,7 +298,7 @@ Name | Type | Description
 A function handler used to cancel the
 subscription at any time.
 
-Defined in: [Hatch.ts:87](https://github.com/TECommons/hatch-connector/blob/main/src/models/Hatch.ts#L87)
+Defined in: [Hatch.ts:87](https://github.com/CommonsSwarm/hatch-connector/blob/main/src/models/Hatch.ts#L87)
 
 ___
 
@@ -320,7 +320,7 @@ Name | Type | Description |
 A function handler used to cancel the
 subscription at any time.
 
-Defined in: [Hatch.ts:50](https://github.com/TECommons/hatch-connector/blob/main/src/models/Hatch.ts#L50)
+Defined in: [Hatch.ts:50](https://github.com/CommonsSwarm/hatch-connector/blob/main/src/models/Hatch.ts#L50)
 
 ___
 
@@ -342,7 +342,7 @@ A promise that resolves to a ForwardingPath
 object which contains all the transactions needed to be signed in order to open
 the hatch.
 
-Defined in: [Hatch.ts:188](https://github.com/TECommons/hatch-connector/blob/main/src/models/Hatch.ts#L188)
+Defined in: [Hatch.ts:188](https://github.com/CommonsSwarm/hatch-connector/blob/main/src/models/Hatch.ts#L188)
 
 ___
 
@@ -365,7 +365,7 @@ A promise that resolves to a ForwardingPath
 object which contains all the transactions needed to be signed in order to get
 a refund from the hatch.
 
-Defined in: [Hatch.ts:245](https://github.com/TECommons/hatch-connector/blob/main/src/models/Hatch.ts#L245)
+Defined in: [Hatch.ts:245](https://github.com/CommonsSwarm/hatch-connector/blob/main/src/models/Hatch.ts#L245)
 
 ___
 
@@ -386,4 +386,4 @@ Name | Type | Description |
 A promise that resolves to the holder
 token balance.
 
-Defined in: [Hatch.ts:260](https://github.com/TECommons/hatch-connector/blob/main/src/models/Hatch.ts#L260)
+Defined in: [Hatch.ts:260](https://github.com/CommonsSwarm/hatch-connector/blob/main/src/models/Hatch.ts#L260)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hatch Connector
 
-Connector for the Hatch frontend implemented using [Aragon Connect](https://aragon.org/connect). It connects to a [hatch subgraph](https://github.com/TECommons/hatch-connector/tree/main/subgraph) created using [The Graph](https://thegraph.com/) indexing protocol.
+Connector for the Hatch frontend implemented using [Aragon Connect](https://aragon.org/connect). It connects to a [hatch subgraph](https://github.com/CommonsSwarm/hatch-connector/tree/main/subgraph) created using [The Graph](https://thegraph.com/) indexing protocol.
 
 The hatch subgraph collects, stores and indexes hatch-related data from the blockchain and serves it through a [GraphQL](https://graphql.org/) endpoint. The connector is an abstraction over this subgraph which offers an API that can be use by any client to fetch data.
 
@@ -16,14 +16,14 @@ See [API.md](./API.md)
 
     ```sh
     yarn add @1hive/connect
-    yarn add @tecommons/connect-hatch
+    yarn add @commonsswarm/connect-hatch
     ```
 
 2.  Import them:
 
     ```js
     import connect from '@1hive/connect'
-    import connectHatch from '@tecommons/connect-hatch'
+    import connectHatch from '@commonsswarm/connect-hatch'
     ```
 
 3.  Set up the connector:
@@ -43,7 +43,7 @@ See [API.md](./API.md)
 
     ```sh
     yarn add @1hive/connect-react
-    yarn add @tecommons/connect-hatch
+    yarn add @commonsswarm/connect-hatch
     ```
 
 2.  Wrap your main `<App/>` component in the `<Connect/>` component provided by the `@1hive/connect-react` library.
@@ -159,6 +159,6 @@ For more information check out the Aragon Connect [docs](https://connect.aragon.
 
 We welcome community contributions!
 
-Please check out our open [Issues](https://github.com/TECommons/hatch-connector/issues) to get started.
+Please check out our open [Issues](https://github.com/CommonsSwarm/hatch-connector/issues) to get started.
 
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@tecommons/connect-hatch",
-  "version": "2.1.5",
+  "name": "@commonsswarm/connect-hatch",
+  "version": "0.0.1",
   "license": "GPL-3.0",
-  "description": "Aragon connector to access and interact with the hatch contract",
-  "author": "TECommons",
+  "description": "Connector to interact with the hatch contract and subgraph",
+  "author": "Commons Swarm",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/cjs/index.d.ts",

--- a/src/thegraph/connector.ts
+++ b/src/thegraph/connector.ts
@@ -20,13 +20,9 @@ export function subgraphUrlFromChainId(
 ): string | null {
   const stagingFragment = staging ? '-staging' : ''
 
-  // Rinkeby
-  if (chainId === 4) {
-    return `https://api.thegraph.com/subgraphs/name/tecommons/aragon-hatch-rinkeby${stagingFragment}`
-  }
   // xDai
   if (chainId === 100) {
-    return `https://api.thegraph.com/subgraphs/name/tecommons/aragon-hatch-xdai${stagingFragment}`
+    return `https://api.thegraph.com/subgraphs/name/commonsswarm/aragon-hatch-xdai${stagingFragment}`
   }
   return null
 }


### PR DESCRIPTION
This PR replaces tecommons for commonsswarm in the connector repo.