### PR TITLE
Hatch state fetching fix

### DIFF
--- a/src/models/ERC20Token.ts
+++ b/src/models/ERC20Token.ts
@@ -4,7 +4,7 @@ class ERC20Token {
   readonly id: string
   readonly name: string
   readonly symbol: string
-  readonly decimals: number
+  readonly decimals: string
 
   constructor(data: ERC20TokenData) {
     this.id = data.id

--- a/src/models/HatchConfig.ts
+++ b/src/models/HatchConfig.ts
@@ -10,15 +10,15 @@ class HatchConfig {
   readonly contributionToken: ERC20Token
   readonly minGoal: string
   readonly maxGoal: string
-  readonly period: number
+  readonly period: string
   readonly exchangeRate: string
-  readonly vestingCliffPeriod: number
-  readonly vestingCompletePeriod: number
+  readonly vestingCliffPeriod: string
+  readonly vestingCompletePeriod: string
   readonly supplyOfferedPct: string
   readonly fundingForBeneficiaryPct: string
-  readonly openDate: number
-  readonly vestingCliffDate: number
-  readonly vestingCompleteDate: number
+  readonly openDate: string
+  readonly vestingCliffDate: string
+  readonly vestingCompleteDate: string
   readonly totalRaised: string
   readonly state: string
   readonly PPM: string

--- a/src/thegraph/connector.ts
+++ b/src/thegraph/connector.ts
@@ -1,5 +1,4 @@
 import { GraphQLWrapper, QueryResult } from '@1hive/connect-thegraph'
-import { Contract } from 'ethers'
 import { SubscriptionHandler } from '@1hive/connect-core'
 import { SubscriptionCallback, IHatchConnector } from '../types'
 import Contribution from '../models/Contribution'

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export interface ERC20TokenData {
   id: string
   name: string
   symbol: string
-  decimals: number
+  decimals: string
 }
 
 export interface HatchOracleConfigData {
@@ -26,15 +26,15 @@ export interface HatchConfigData {
   contributionToken: ERC20TokenData
   minGoal: string
   maxGoal: string
-  period: number
+  period: string
   exchangeRate: string
-  vestingCliffPeriod: number
-  vestingCompletePeriod: number
+  vestingCliffPeriod: string
+  vestingCompletePeriod: string
   supplyOfferedPct: string
   fundingForBeneficiaryPct: string
-  openDate: number
-  vestingCliffDate: number
-  vestingCompleteDate: number
+  openDate: string
+  vestingCliffDate: string
+  vestingCompleteDate: string
   totalRaised: string
   state: string
   PPM: string

--- a/src/utils/app-utils.ts
+++ b/src/utils/app-utils.ts
@@ -7,6 +7,7 @@ import {
   STATE_FUNDING,
   STATE_REFUNDING,
 } from '../hatch-states'
+
 export const IMPACT_HOURS_APP = 'impact-hours-beta'
 export const HATCH_APP = 'marketplace-hatch'
 export const HATCH_ORACLE_APP = 'hatch-oracle'
@@ -16,12 +17,17 @@ export function calculateHatchState(
   subgraphState: string
 ): string {
   const now = Date.now() / 1000
+  const totalRaised = BigNumber.from(hatch.totalRaised)
+  const maxGoal = BigNumber.from(hatch.maxGoal)
+  const minGoal = BigNumber.from(hatch.minGoal)
+  const openDate = Number(hatch.openDate)
+  const period = Number(hatch.period)
 
-  if (hatch.openDate === 0 || hatch.openDate > now) {
+  if (openDate === 0 || openDate > now) {
     return STATE_PENDING
   }
 
-  if (hatch.totalRaised >= hatch.maxGoal) {
+  if (totalRaised.gte(maxGoal)) {
     if (subgraphState === STATE_CLOSED) {
       return STATE_CLOSED
     } else {
@@ -29,9 +35,9 @@ export function calculateHatchState(
     }
   }
 
-  if (now - hatch.openDate < hatch.period) {
+  if (now - openDate < period) {
     return STATE_FUNDING
-  } else if (BigNumber.from(hatch.totalRaised).gte(hatch.minGoal)) {
+  } else if (totalRaised.gte(minGoal)) {
     if (subgraphState === STATE_CLOSED) {
       return STATE_CLOSED
     } else {

--- a/subgraph/src/Hatch.ts
+++ b/subgraph/src/Hatch.ts
@@ -11,16 +11,7 @@ import {
   getContributorEntity,
   getHatchState,
 } from './helpers'
-import {
-  STATE_CLOSED,
-  STATE_CLOSED_NUM,
-  STATE_GOAL_REACHED,
-  STATE_GOAL_REACHED_NUM,
-  getIntStateByKey,
-  getStateByKey,
-  STATE_REFUNDING,
-  STATE_REFUNDING_NUM,
-} from './hatch-states'
+import { getIntStateByKey, getStateByKey } from './hatch-states'
 
 export function handleSetOpenDate(event: SetOpenDateEvent): void {
   const config = getHatchConfigEntity(event.address)
@@ -31,6 +22,7 @@ export function handleSetOpenDate(event: SetOpenDateEvent): void {
   ])
 
   config.openDate = event.params.date
+
   config.state = getStateByKey(stateKey)
   config.stateInt = getIntStateByKey(stateKey)
 
@@ -39,11 +31,12 @@ export function handleSetOpenDate(event: SetOpenDateEvent): void {
 
 export function handleClose(event: CloseEvent): void {
   const config = getHatchConfigEntity(event.address)
+  const stateKey = getHatchState(event.address)
 
   log.debug('Closed event received.', [])
 
-  config.state = STATE_CLOSED
-  config.stateInt = STATE_CLOSED_NUM
+  config.state = getStateByKey(stateKey)
+  config.stateInt = getIntStateByKey(stateKey)
 
   config.save()
 }
@@ -57,15 +50,14 @@ export function handleContribute(event: ContributeEvent): void {
   )
   const contributor = getContributorEntity(event.address, params.contributor)
   const config = getHatchConfigEntity(event.address)
+  const stateKey = getHatchState(event.address)
 
   contributor.totalValue = contributor.totalValue.plus(params.value)
   contributor.totalAmount = contributor.totalAmount.plus(params.amount)
-  config.totalRaised = config.totalRaised.plus(params.value)
 
-  if (config.totalRaised.ge(config.minGoal)) {
-    config.state = STATE_GOAL_REACHED
-    config.stateInt = STATE_GOAL_REACHED_NUM
-  }
+  config.totalRaised = config.totalRaised.plus(params.value)
+  config.stateInt = getIntStateByKey(stateKey)
+  config.state = getStateByKey(stateKey)
 
   contribution.value = params.value
   contribution.amount = params.amount
@@ -95,9 +87,10 @@ export function handleRefund(event: RefundEvent): void {
     params.contributor,
     params.vestedPurchaseId
   )
+  const stateKey = getHatchState(event.address)
 
-  config.state = STATE_REFUNDING
-  config.stateInt = STATE_REFUNDING_NUM
+  config.state = getStateByKey(stateKey)
+  config.stateInt = getIntStateByKey(stateKey)
   contributor.totalValue = contributor.totalValue.minus(params.value)
   contributor.totalAmount = contributor.totalAmount.minus(params.amount)
 


### PR DESCRIPTION
This PR fixes hatch state fetching both in the connector and subgraph.

Connector's class model attributes were set to `string` to avoid pointless object instantiations when returning the same query result in GraphQL subscriptions. 